### PR TITLE
Day 8 - Treetop Tree House

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use puzzles::reorg;
 use puzzles::stacks;
 use puzzles::tuning;
 use puzzles::filewalk;
+use puzzles::trees;
 
 fn read_file(filename: &str) -> String {
     match fs::read_to_string(filename.to_string()) {
@@ -65,6 +66,11 @@ fn main() {
             let part1 = filewalk::biggest_small_dirs(&day7);
             let part2 = filewalk::smallest_big_dir(&day7);
             println!("Question 7: {part1}, {part2}");
+        },
+        8 => {
+            let day8 = read_file("in8.txt");
+            let part1 = trees::count_visible_trees(&day8);
+            println!("Question 8: {part1}");
         }
         n => {
             println!("No entry for day {n}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,8 @@ fn main() {
         8 => {
             let day8 = read_file("in8.txt");
             let part1 = trees::count_visible_trees(&day8);
-            println!("Question 8: {part1}");
+            let part2 = trees::best_scenic_score(&day8);
+            println!("Question 8: {part1}, {part2}");
         }
         n => {
             println!("No entry for day {n}");

--- a/src/puzzles.rs
+++ b/src/puzzles.rs
@@ -5,3 +5,4 @@ pub mod cleanup;
 pub mod stacks;
 pub mod tuning;
 pub mod filewalk;
+pub mod trees;

--- a/src/puzzles/trees.rs
+++ b/src/puzzles/trees.rs
@@ -1,0 +1,51 @@
+
+type TreeGrid = Vec<Vec<u32>>;
+
+fn read_tree_grid(input: &String) -> TreeGrid{
+    input.trim().lines().map(|l| {
+        l.chars().map(|c| c.to_digit(10).unwrap()).collect()
+    }).collect()
+}
+
+fn can_see_edge(row: usize, column: usize, grid: &TreeGrid) -> bool{
+    let value = grid[row][column];
+    let height = grid.len();
+    let width = grid[row].len();
+
+    let left    = (0..column).rev().all(|temp_column| grid[row][temp_column] < value);
+    let right   = (column+1..width).all(|temp_column| grid[row][temp_column] < value);
+    let up      = (0..row).rev().all(|temp_row| grid[temp_row][column] < value);
+    let down    = (row+1..height).rev().all(|temp_row| grid[temp_row][column] < value);
+
+    left || right || up || down
+}
+
+fn count_edgeview_trees(grid: &TreeGrid) -> u32{
+    grid.iter().enumerate().map(|(row, cells)| 
+        cells.iter().enumerate().filter(|(column, _value)| can_see_edge(row, *column, grid)).count() as u32
+    ).sum()
+}
+
+pub fn count_visible_trees(input: &String) -> u32 {
+    let grid = read_tree_grid(input);
+    count_edgeview_trees(&grid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn part_one() {
+        let input = r"
+30373
+25512
+65332
+33549
+35390".to_string();
+
+        let grid = read_tree_grid(&input);
+        let edge_count = count_edgeview_trees(&grid);
+        assert_eq!(edge_count, 21);
+    }
+}

--- a/src/puzzles/trees.rs
+++ b/src/puzzles/trees.rs
@@ -20,6 +20,36 @@ fn can_see_edge(row: usize, column: usize, grid: &TreeGrid) -> bool{
     left || right || up || down
 }
 
+fn trees_on_path(path: &Vec<(usize, usize)>, grid: &TreeGrid, start_value: u32) -> u32 {
+    let mut seen_count: u32 = 0;
+    for i in 0..path.len() {
+        let (row, column) = path[i];
+        let seen_value = grid[row][column];
+        if seen_value < start_value {
+            seen_count += 1;
+        } else {
+            seen_count += 1;
+            return seen_count;
+        }
+    }
+    seen_count
+}
+
+fn scenic_score(row: usize, column: usize, grid: &TreeGrid) -> u32 {
+    let value = grid[row][column];
+    let height = grid.len();
+    let width = grid[row].len();
+
+    let quick_trees = |path: &Vec<(usize, usize)>| trees_on_path(path, grid, value);
+
+    let left    = quick_trees(&(0..column).rev().map(|temp_column| (row, temp_column)).collect());
+    let right   = quick_trees(&(column+1..width).map(|temp_column| (row, temp_column)).collect());
+    let up      = quick_trees(&(0..row).rev().map(|temp_row| (temp_row, column)).collect());
+    let down    = quick_trees(&(row+1..height).map(|temp_row| (temp_row, column)).collect());
+
+    left * right * up * down
+}
+
 fn count_edgeview_trees(grid: &TreeGrid) -> u32{
     grid.iter().enumerate().map(|(row, cells)| 
         cells.iter().enumerate().filter(|(column, _value)| can_see_edge(row, *column, grid)).count() as u32
@@ -29,6 +59,13 @@ fn count_edgeview_trees(grid: &TreeGrid) -> u32{
 pub fn count_visible_trees(input: &String) -> u32 {
     let grid = read_tree_grid(input);
     count_edgeview_trees(&grid)
+}
+
+pub fn best_scenic_score(input: &String) -> u32{
+    let grid = read_tree_grid(input);
+    grid.iter().enumerate().map(|(row, cells)|
+        cells.iter().enumerate().map(|(column, _value)| scenic_score(row, column, &grid)).max().unwrap())
+        .max().unwrap()
 }
 
 #[cfg(test)]
@@ -47,5 +84,17 @@ mod tests {
         let grid = read_tree_grid(&input);
         let edge_count = count_edgeview_trees(&grid);
         assert_eq!(edge_count, 21);
+    }
+
+    #[test]
+    fn part_two() {
+        let input = r"
+30373
+25512
+65332
+33549
+35390".to_string();
+
+        assert_eq!(best_scenic_score(&input), 8);
     }
 }


### PR DESCRIPTION
Thankfully a much easier puzzle than yesterday.

Using index syntax rather than `get` to bypass some of the error checking. Will crash mightily if a bad index creeps in, but it should be fine for this.

An extremely good use for lazy iterator logic in this puzzle. My answers are pretty much a series of `iter().enumerate().map`.

---

Reading through this again I realise that I've made it way more complicated than it needs to be. For part two I could have just passed through the values directly instead of enumerating and relating to the grid. Ah well, it works well enough.