### PR TITLE
Day 9 - Rope Bridge

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use puzzles::stacks;
 use puzzles::tuning;
 use puzzles::filewalk;
 use puzzles::trees;
+use puzzles::tail_follow;
 
 fn read_file(filename: &str) -> String {
     match fs::read_to_string(filename.to_string()) {
@@ -72,6 +73,11 @@ fn main() {
             let part1 = trees::count_visible_trees(&day8);
             let part2 = trees::best_scenic_score(&day8);
             println!("Question 8: {part1}, {part2}");
+        },
+        9 => {
+            let day9 = read_file("in9.txt");
+            let part1 = tail_follow::tail_visited_positions(&day9);
+            println!("Question 9: {part1}");
         }
         n => {
             println!("No entry for day {n}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,8 @@ fn main() {
         9 => {
             let day9 = read_file("in9.txt");
             let part1 = tail_follow::tail_visited_positions(&day9);
-            println!("Question 9: {part1}");
+            let part2 = tail_follow::many_tail_visited_positions(&day9);
+            println!("Question 9: {part1}, {part2}");
         }
         n => {
             println!("No entry for day {n}");

--- a/src/puzzles.rs
+++ b/src/puzzles.rs
@@ -6,3 +6,4 @@ pub mod stacks;
 pub mod tuning;
 pub mod filewalk;
 pub mod trees;
+pub mod tail_follow;

--- a/src/puzzles/tail_follow.rs
+++ b/src/puzzles/tail_follow.rs
@@ -1,0 +1,130 @@
+use std::collections::HashSet;
+enum Direction {
+    Right,
+    Left,
+    Up,
+    Down
+}
+
+type Motion = (Direction, i32);
+type Position = (i32, i32);
+type World = (Position, Position, HashSet<Position>);
+
+fn parse_motions(input: &String) -> Vec<Motion>{
+    use Direction::*;
+    input.trim().lines().map(|l| {
+        let mut parts = l.split(" ");
+        let dir = match parts.next().unwrap() {
+            "R" => Right,
+            "L" => Left,
+            "U" => Up,
+            "D" => Down,
+            n => panic!("Unrecognized direction {n}")
+        };
+        let distance: i32 = parts.next().unwrap().parse().unwrap();
+        (dir, distance)
+    }).collect()
+}
+
+fn coord_delta(d: &Direction) -> Position {
+    use Direction::*;
+    match d {
+        Right => (1, 0),
+        Left => (-1, 0),
+        Up => (0, -1),
+        Down => (0, 1)
+    }
+}
+
+fn tail_chase(head: Position, tail:Position) -> Position {
+    let (head_x, head_y) = head;
+    let (tail_x, tail_y) = tail;
+
+    let diff_x = head_x - tail_x;
+    let diff_y = head_y - tail_y;
+
+    let mut out_x = tail_x;
+    let mut out_y = tail_y;
+
+    if diff_x.abs() <= 1 && diff_y.abs() <= 1 {
+        return tail
+    }
+
+    if diff_x >= 2 {
+        out_x = tail_x + 1;
+        if diff_y != 0 {
+            out_y = tail_y + diff_y.signum();
+        }
+    }
+    if diff_x <= -2 {
+        out_x = tail_x - 1;
+        if diff_y != 0 {
+            out_y = tail_y + diff_y.signum();
+        }
+    }
+    if diff_y >= 2 {
+        out_y = tail_y + 1;
+        if diff_x != 0 {
+            out_x = tail_x + diff_x.signum();
+        }
+    }
+    if diff_y <= -2 {
+        out_y = tail_y - 1;
+        if diff_x != 0 {
+            out_x = tail_x + diff_x.signum();
+        }
+    }
+
+    (out_x, out_y)
+}
+
+fn update_world(world: World, motion: Motion) -> World {
+    let (head, tail, mut visited) = world;
+    let (dir, steps) = motion;
+    let (mut head_x, mut head_y) = head;
+    let (mut tail_x, mut tail_y) = tail;
+
+    let (delta_x, delta_y) = coord_delta(&dir);
+
+    for _ in 0..steps {
+        head_x += delta_x;
+        head_y += delta_y;
+
+        (tail_x, tail_y) = tail_chase((head_x, head_y), (tail_x, tail_y));
+        visited.insert((tail_x, tail_y));
+    }
+
+    ((head_x, head_y), (tail_x, tail_y), visited)
+}
+
+pub fn tail_visited_positions(input: &String) -> u32 {
+    let motions = parse_motions(input);
+    let mut world: World = ((0, 0), (0, 0), HashSet::new());
+
+    for motion in motions {
+        world = update_world(world, motion);
+    }
+
+    let (_, _, visited) = world;
+    visited.len() as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn part_one() {
+        let input = r"
+R 4
+U 4
+L 3
+D 1
+R 4
+D 1
+L 5
+R 2
+        ".to_string();
+        assert_eq!(tail_visited_positions(&input), 13);
+    }
+}


### PR DESCRIPTION
This one was interesting. I was afraid it was going to get really complicated for part two, but most of my logic could be copied over well, I seem to have broken down my `tail_chase` method in just the right way.

This is the first time where I'm starting to get used to Rust's concept of borrowing. It has taken me awhile to realise that Rust doesn't really have the concept of `ByVal` and `ByRef` that we see in other languages. Instead, a variable can be borrowed or pointed to, or pointed to in a mutable way.

To describe how this is kinda weird I'll give an example from today. look at the signature of my `update_world` function here:

```
fn update_world(world: World, motion: Motion) -> World
```

This looks straightforward, you put in a world state and a motion and get a new world state at the end. But that doesn't tell the whole story. I know it doesn't look like it, but this function performs a **MUTATION**, sort of.

The trick is that when the `world` parameter is loaded in, _ownership_ of it is passed from the caller to this function. What this means is that the source function **CANNOT USE THIS VARIABLE ANYMORE**. The rust compiler will complain at you if you try.

>Use of moved value
>Value moved here
>Move occurs because `<variable>` has `<type>` which does not implement the Copy trait

So for most types, unless you explicitly implement the `Copy` trait then you are transferring ownership when you pass it as a parameter. 

I'm not sure how this plays with some common data structures like `Vec` or `HashMap`. If those implement the `Copy` trait then functions that `borrow` them might be getting a copied version. I'll need to play about with it a bit more to find out. 

At any rate, what I'm using right now is a tuple which definitely does not implement the copy trait, so this is defnitely transferring ownership.

I'm not sure I've got the whole story, but it is good knowledge.